### PR TITLE
[ALL] Add package version to `__init__` and check Python version

### DIFF
--- a/src/py_sofistik_utils/__init__.py
+++ b/src/py_sofistik_utils/__init__.py
@@ -1,0 +1,17 @@
+# standard library imports
+from sys import version_info
+if version_info < (3, 12):
+    raise ImportError("py-sofistik-utils does not support Python < 3.12!")
+
+# third party library imports
+
+# local library specific imports
+from py_sofistik_utils.cdb_reader import SOFiSTiKCDBReader
+
+
+__version__ = "0.0.1-dev1"
+
+__all__ = (
+    "__version__",
+    "SOFiSTiKCDBReader"
+)


### PR DESCRIPTION
This PR:
- add the `__version__` to the package
- clean-up the import mechanism as much as possible 